### PR TITLE
Fix race condition when initializing HealthCheckedEndpointGroup

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -561,7 +561,7 @@ class HealthCheckedEndpointGroupTest {
                                                     ClientOptions.of(), checkFactory,
                                                     HealthCheckStrategy.all(),
                                                     DEFAULT_ENDPOINT_PREDICATE)) {
-            endpointGroup.addListener(endpointsListener, true);
+            endpointGroup.addListener(endpointsListener, false);
             await().untilAsserted(() -> assertThat(updateInvokedCounter).hasValue(1));
             // the counter should stay 1 after 1 second has passed
             await().pollDelay(1, TimeUnit.SECONDS)


### PR DESCRIPTION
Motivation:

To Fix flaky tests named CacheReflectsAttributeChanges

Modifications:

addListener with notifyLatestValue false 

Result:

Local Test work successfully, but it fails when [build-ubicloud-standard-16-jdk-11]
So, I opened this pull request on my repository to run CI locally
