### PR TITLE
Expose response headers in DocsService

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -663,11 +663,9 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       >
                         {JSON.stringify(
                           Object.fromEntries(
-                            debugResponseHeaders
-                              .entries()
-                              .flatMap(([key, values]) =>
-                                values.map((value) => [key, value]),
-                              ),
+                            Array.from(debugResponseHeaders).map(
+                              ([key, values]) => [key, values.join(', ')],
+                            ),
                           ),
                           null,
                           2,
@@ -783,9 +781,8 @@ const DebugPage: React.FunctionComponent<Props> = ({
                     >
                       {JSON.stringify(
                         Object.fromEntries(
-                          Array.from(debugResponseHeaders.entries()).flatMap(
-                            ([key, values]) =>
-                              values.map((value) => [key, value]),
+                          Array.from(debugResponseHeaders).map(
+                            ([key, values]) => [key, values.join(', ')],
                           ),
                         ),
                         null,

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -16,8 +16,8 @@
 import JSONbig from 'json-bigint';
 import { jsonPrettify } from '../json-util';
 import { docServiceDebug, providers } from '../header-provider';
-
 import { Endpoint, Method } from '../specification';
+import { ResponseData } from '../types';
 
 export default abstract class Transport {
   public abstract supportsMimeType(mimeType: string): boolean;
@@ -31,7 +31,7 @@ export default abstract class Transport {
     bodyJson?: string,
     endpointPath?: string,
     queries?: string,
-  ): Promise<{ body: string; headers: Record<string, string> }> {
+  ): Promise<ResponseData> {
     const providedHeaders = await Promise.all(
       providers.map((provider) => provider()),
     );
@@ -59,9 +59,9 @@ export default abstract class Transport {
       endpointPath,
       queries,
     );
-    const responseHeaders = this.extractHeaders(httpResponse.headers);
-    const responseText = await httpResponse.text();
-    const applicationType = httpResponse.headers.get('content-type') || '';
+    const responseHeaders = httpResponse.headers;
+    const responseText = httpResponse.body;
+    const applicationType = responseHeaders.get('content-type') || '';
     if (applicationType.indexOf('json') >= 0) {
       try {
         const json = JSONbig.parse(responseText);
@@ -181,5 +181,5 @@ export default abstract class Transport {
     bodyJson?: string,
     endpointPath?: string,
     queries?: string,
-  ): Promise<Response>;
+  ): Promise<ResponseData>;
 }

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -92,14 +92,6 @@ export default abstract class Transport {
     };
   }
 
-  protected extractHeaders(headers: Headers): Record<string, string> {
-    const result: Record<string, string> = {};
-    headers.forEach((value, key) => {
-      result[key] = value;
-    });
-    return result;
-  }
-
   public findDebugMimeTypeEndpoint(
     method: Method,
     endpointPath?: string,

--- a/docs-client/src/lib/types.ts
+++ b/docs-client/src/lib/types.ts
@@ -24,3 +24,8 @@ export enum SpecLoadingStatus {
   FAILED,
   SUCCESS,
 }
+
+export interface ResponseData {
+  body: string;
+  headers: Map<string, string[]>;
+}


### PR DESCRIPTION
Motivation

I lacked a clear understanding of handling multi-value HTTP headers. After reviewing RFC9110 §5.2, I realized headers should either be comma-separated or explicitly allowed as repeated fields.

Modification
	•	Defined ResponseData (body + headers) in types.tsx.
	•	Updated abstract doSend to return ResponseData instead of Response.
	•	Aggregated multi-value headers into Map<string, string[]>.
	•	Adjusted DebugPage to display headers per RFC9110 guidelines.

Result

Headers now correctly display multi-value fields (e.g., "x-role": "admin, editor, user").