### PR TITLE
Update PR comment

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -130,9 +130,11 @@ const toggle = (prev: boolean, override: unknown) => {
 
 const escapeSingleQuote = (text: string) => text.replace(/'/g, "'\\''");
 
+type Header = [name: string, value: string];
+
 interface ResponseData {
+  headers: Header[];
   body: string;
-  headers: Record<string, string>;
 }
 
 const DebugPage: React.FunctionComponent<Props> = ({
@@ -154,9 +156,9 @@ const DebugPage: React.FunctionComponent<Props> = ({
   const [requestBody, setRequestBody] = useState('');
   const [debugResponse, setDebugResponse] = useState('');
   const [additionalQueries, setAdditionalQueries] = useState('');
-  const [debugResponseHeaders, setDebugResponseHeaders] = useState<
-    Record<string, string>
-  >({});
+  const [debugResponseHeaders, setDebugResponseHeaders] = useState<Header[]>(
+    [],
+  );
   const [additionalPath, setAdditionalPath] = useState('');
   const [additionalHeaders, setAdditionalHeaders] = useState('');
   const [stickyHeaders, toggleStickyHeaders] = useReducer(toggle, false);
@@ -190,7 +192,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
         setDebugResponseHeaders(responseCache[apiId].headers);
       } else {
         setDebugResponse('');
-        setDebugResponseHeaders({});
+        setDebugResponseHeaders([]);
       }
     }
   }, [method, currentApiId, responseCache]);
@@ -231,7 +233,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
     if (!keepDebugResponse) {
       setDebugResponse('');
-      setDebugResponseHeaders({});
+      setDebugResponseHeaders([]);
       toggleKeepDebugResponse(false);
     }
     setSnackbarOpen(false);
@@ -394,7 +396,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
   const onClear = useCallback(() => {
     setDebugResponse('');
-    setDebugResponseHeaders({});
+    setDebugResponseHeaders([]);
   }, []);
 
   const executeRequest = useCallback(
@@ -431,15 +433,15 @@ const DebugPage: React.FunctionComponent<Props> = ({
           queries,
         );
         setDebugResponse(body);
-        setDebugResponseHeaders(responseHeaders);
+        setDebugResponseHeaders(Object.entries(responseHeaders));
         setResponseCache((prev) => ({
           ...prev,
-          [currentApiId]: { body, headers: responseHeaders },
+          [currentApiId]: { body, headers: Object.entries(responseHeaders) },
         }));
       } catch (e) {
         const message = e instanceof Object ? e.toString() : '<unknown>';
         setDebugResponse(message);
-        setDebugResponseHeaders({});
+        setDebugResponseHeaders([]);
       }
     },
     [
@@ -548,7 +550,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
         setDebugResponseHeaders(responseCache[newApiId].headers);
       } else {
         setDebugResponse('');
-        setDebugResponseHeaders({});
+        setDebugResponseHeaders([]);
       }
     }
   }, [method, currentApiId, responseCache]);
@@ -659,7 +661,11 @@ const DebugPage: React.FunctionComponent<Props> = ({
                         style={githubGist}
                         wrapLines={false}
                       >
-                        {JSON.stringify(debugResponseHeaders, null, 2)}
+                        {JSON.stringify(
+                          Object.fromEntries(debugResponseHeaders),
+                          null,
+                          2,
+                        )}
                       </SyntaxHighlighter>
                     </>
                   )}
@@ -769,7 +775,11 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       style={githubGist}
                       wrapLines={false}
                     >
-                      {JSON.stringify(debugResponseHeaders, null, 2)}
+                      {JSON.stringify(
+                        Object.fromEntries(debugResponseHeaders),
+                        null,
+                        2,
+                      )}
                     </SyntaxHighlighter>
                   </>
                 )}

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -295,6 +295,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
       }
 
       // window.location.origin may have compatibility issue
+      // https://developer.mozilla.org/en-US/docs/Web/API/Window/location#Browser_compatibility
       const host =
         `${window.location.protocol}//${window.location.hostname}` +
         `${window.location.port ? `:${window.location.port}` : ''}`;
@@ -461,6 +462,10 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
     try {
       if (useRequestBody) {
+        // Do not round-trip through JSON.parse to minify the text so as to not lose numeric precision.
+        // See: https://github.com/line/armeria/issues/273
+
+        // For some reason jsonMinify minifies {} as empty string, so work around it.
         params.set('request_body', jsonMinify(requestBody) || '{}');
       }
 
@@ -477,6 +482,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
       } else if (additionalPath.length > 0) {
         params.set('endpoint_path', additionalPath);
       } else {
+        // Fall back to default endpoint.
         params.delete('endpoint_path');
       }
 
@@ -511,6 +517,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
     const serializedParams = `?${params.toString()}`;
     if (serializedParams !== location.search) {
+      // executeRequest may throw error before useEffect, we need to avoid useEffect cleanup the debug response.
       toggleKeepDebugResponse(true);
       history.push(`${location.pathname}${serializedParams}`);
     }

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -663,11 +663,9 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       >
                         {JSON.stringify(
                           Object.fromEntries(
-                            debugResponseHeaders
-                              .entries()
-                              .flatMap(([key, values]) =>
-                                values.map((value) => [key, value]),
-                              ),
+                            Array.from(debugResponseHeaders).map(
+                              ([key, values]) => [key, values.join(', ')],
+                            ),
                           ),
                           null,
                           2,
@@ -783,9 +781,8 @@ const DebugPage: React.FunctionComponent<Props> = ({
                     >
                       {JSON.stringify(
                         Object.fromEntries(
-                          Array.from(debugResponseHeaders.entries()).flatMap(
-                            ([key, values]) =>
-                              values.map((value) => [key, value]),
+                          Array.from(debugResponseHeaders).map(
+                            ([key, values]) => [key, values.join(', ')],
                           ),
                         ),
                         null,

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -16,8 +16,8 @@
 import JSONbig from 'json-bigint';
 import { jsonPrettify } from '../json-util';
 import { docServiceDebug, providers } from '../header-provider';
-
 import { Endpoint, Method } from '../specification';
+import { ResponseData } from '../types';
 
 export default abstract class Transport {
   public abstract supportsMimeType(mimeType: string): boolean;
@@ -31,7 +31,7 @@ export default abstract class Transport {
     bodyJson?: string,
     endpointPath?: string,
     queries?: string,
-  ): Promise<{ body: string; headers: Record<string, string> }> {
+  ): Promise<ResponseData> {
     const providedHeaders = await Promise.all(
       providers.map((provider) => provider()),
     );
@@ -59,9 +59,9 @@ export default abstract class Transport {
       endpointPath,
       queries,
     );
-    const responseHeaders = this.extractHeaders(httpResponse.headers);
-    const responseText = await httpResponse.text();
-    const applicationType = httpResponse.headers.get('content-type') || '';
+    const responseHeaders = httpResponse.headers;
+    const responseText = httpResponse.body;
+    const applicationType = responseHeaders.get('content-type') || '';
     if (applicationType.indexOf('json') >= 0) {
       try {
         const json = JSONbig.parse(responseText);
@@ -181,5 +181,5 @@ export default abstract class Transport {
     bodyJson?: string,
     endpointPath?: string,
     queries?: string,
-  ): Promise<Response>;
+  ): Promise<ResponseData>;
 }

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -92,14 +92,6 @@ export default abstract class Transport {
     };
   }
 
-  protected extractHeaders(headers: Headers): Record<string, string> {
-    const result: Record<string, string> = {};
-    headers.forEach((value, key) => {
-      result[key] = value;
-    });
-    return result;
-  }
-
   public findDebugMimeTypeEndpoint(
     method: Method,
     endpointPath?: string,

--- a/docs-client/src/lib/types.ts
+++ b/docs-client/src/lib/types.ts
@@ -24,3 +24,8 @@ export enum SpecLoadingStatus {
   FAILED,
   SUCCESS,
 }
+
+export interface ResponseData {
+  body: string;
+  headers: Map<string, string[]>;
+}


### PR DESCRIPTION
 Motivation

1. I handled method.id with a fallback to method.name assuming that method.id might be null.
2. After reviewing the backend code (MethodInfo.java), we realized that id() is always non-null.
3. duplicated useEffect in the debug modal was present under the assumption that the modal needed to track method.id changes.

 Modification
- Removed fallback from method.id || method.name to just method.id.
- Deleted the useEffect block inside the debug modal, as method.id never changes in that context.
- Removed duplicated logics in each transport.tsx

Result
- Code simplified with fewer conditionals and duplication.
- The debug modal and inline debug form now behave as intended without unnecessary effect handlers.