### PR TITLE
Update PR comment

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -539,22 +539,6 @@ const DebugPage: React.FunctionComponent<Props> = ({
     transport,
   ]);
 
-  useEffect(() => {
-    const newApiId = method.id || method.name;
-    if (newApiId !== currentApiId) {
-      setCurrentApiId(newApiId);
-      if (responseCache[newApiId]) {
-        setDebugResponse(responseCache[newApiId].body);
-        setDebugResponseHeaders(
-          Array.from(responseCache[newApiId].headers.entries()),
-        );
-      } else {
-        setDebugResponse('');
-        setDebugResponseHeaders([]);
-      }
-    }
-  }, [method, currentApiId, responseCache]);
-
   const supportedExamplePaths = useMemo(() => {
     if (
       serviceType === ServiceType.HTTP ||

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -59,6 +59,12 @@ import { TRANSPORTS } from '../../lib/transports';
 import { SelectOption } from '../../lib/types';
 import DebugInputs from './DebugInputs';
 
+const stringifyHeaders = (headers: [string, string[]][]): string =>
+  JSON.stringify(
+    Object.fromEntries(headers.map(([key, value]) => [key, value.join(', ')])),
+    null,
+    2,
+  );
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     actionDialog: {
@@ -645,15 +651,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
                         style={githubGist}
                         wrapLines={false}
                       >
-                        {JSON.stringify(
-                          Object.fromEntries(
-                            Array.from(debugResponseHeaders).map(
-                              ([key, values]) => [key, values.join(', ')],
-                            ),
-                          ),
-                          null,
-                          2,
-                        )}
+                        {stringifyHeaders(debugResponseHeaders)}
                       </SyntaxHighlighter>
                     </>
                   )}
@@ -763,15 +761,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       style={githubGist}
                       wrapLines={false}
                     >
-                      {JSON.stringify(
-                        Object.fromEntries(
-                          Array.from(debugResponseHeaders).map(
-                            ([key, values]) => [key, values.join(', ')],
-                          ),
-                        ),
-                        null,
-                        2,
-                      )}
+                      {stringifyHeaders(debugResponseHeaders)}
                     </SyntaxHighlighter>
                   </>
                 )}

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -168,9 +168,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
     false,
   );
 
-  const [currentApiId, setCurrentApiId] = useState<string>(
-    method.id || method.name,
-  );
+  const [currentApiId, setCurrentApiId] = useState<string>(method.id);
   const [responseCache, setResponseCache] = useState<
     Record<string, { body: string; headers: Map<string, string[]> }>
   >({});
@@ -183,7 +181,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
   }
 
   useEffect(() => {
-    const apiId = method.id || method.name;
+    const apiId = method.id;
     if (apiId !== currentApiId) {
       setCurrentApiId(apiId);
       if (responseCache[apiId]) {

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -340,23 +340,23 @@ const DebugPage: React.FunctionComponent<Props> = ({
         escapeSingleQuote(requestBody),
       );
 
-      const headersObj = new Headers();
-      headersObj.set('content-type', transport.getDebugMimeType());
+      const headers = new Headers();
+      headers.set('content-type', transport.getDebugMimeType());
       if (process.env.WEBPACK_DEV === 'true') {
-        headersObj.set(docServiceDebug, 'true');
+        headers.set(docServiceDebug, 'true');
       }
       if (serviceType === ServiceType.GRAPHQL) {
-        headersObj.set('accept', 'application/json');
+        headers.set('accept', 'application/json');
       }
       if (additionalHeaders) {
         const entries = Object.entries(JSON.parse(additionalHeaders));
         entries.forEach(([key, value]) => {
-          headersObj.set(key, String(value));
+          headers.set(key, String(value));
         });
       }
 
       const headerOptions: string[] = [];
-      headersObj.forEach((value, key) => {
+      headers.forEach((value, key) => {
         headerOptions.push(`-H '${key}: ${value}'`);
       });
 

--- a/docs-client/src/lib/json-util.ts
+++ b/docs-client/src/lib/json-util.ts
@@ -134,3 +134,17 @@ export function isValidJsonMimeType(applicationType: string | null) {
   }
   return applicationType.indexOf('json') >= 0;
 }
+
+export function extractResponseHeaders(
+  headers: Headers,
+): Map<string, string[]> {
+  const responseHeaders = new Map<string, string[]>();
+  headers.forEach((value, key) => {
+    const lowerKey = key.toLowerCase();
+    if (!responseHeaders.has(lowerKey)) {
+      responseHeaders.set(lowerKey, []);
+    }
+    responseHeaders.get(lowerKey)!.push(value);
+  });
+  return responseHeaders;
+}

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -16,7 +16,11 @@
 import { Endpoint, Method } from '../specification';
 
 import Transport from './transport';
-import { isValidJsonMimeType, validateJsonObject } from '../json-util';
+import {
+  extractResponseHeaders,
+  isValidJsonMimeType,
+  validateJsonObject,
+} from '../json-util';
 import { ResponseData } from '../types';
 
 export const ANNOTATED_HTTP_MIME_TYPE = 'application/json; charset=utf-8';
@@ -123,15 +127,7 @@ export default class AnnotatedHttpTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/grahpql-http.ts
+++ b/docs-client/src/lib/transports/grahpql-http.ts
@@ -16,7 +16,7 @@
 
 import Transport from './transport';
 import { Method } from '../specification';
-import { validateJsonObject } from '../json-util';
+import { extractResponseHeaders, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const GRAPHQL_HTTP_MIME_TYPE = 'application/graphql+json';
@@ -66,15 +66,7 @@ export default class GraphqlHttpTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/grpc-unframed.ts
+++ b/docs-client/src/lib/transports/grpc-unframed.ts
@@ -16,7 +16,7 @@
 import { Method } from '../specification';
 
 import Transport from './transport';
-import { validateJsonObject } from '../json-util';
+import { extractResponseHeaders, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const GRPC_UNFRAMED_MIME_TYPE =
@@ -63,15 +63,7 @@ export default class GrpcUnframedTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/thrift.ts
+++ b/docs-client/src/lib/transports/thrift.ts
@@ -17,7 +17,7 @@
 import { Endpoint, Method } from '../specification';
 
 import Transport from './transport';
-import { validateJsonObject } from '../json-util';
+import { extractResponseHeaders, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const TTEXT_MIME_TYPE = 'application/x-thrift; protocol=TTEXT';
@@ -73,15 +73,7 @@ export default class ThriftTransport extends Transport {
       body: `{"method": "${thriftMethod}", "type": "CALL", "args": ${bodyJson}}`,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {


### PR DESCRIPTION
Motivation

I handled method.id with a fallback to method.name assuming that method.id might be null.
After reviewing the backend code (MethodInfo.java), we realized that id() is always non-null.
duplicated useEffect in the debug modal was present under the assumption that the modal needed to track method.id changes.
Modification

Removed fallback from method.id || method.name to just method.id.
Deleted the useEffect block inside the debug modal, as method.id never changes in that context.
Removed duplicated logics in each transport.tsx
Result

Code simplified with fewer conditionals and duplication.
The debug modal and inline debug form now behave as intended without unnecessary effect handlers.