### PR TITLE
Update Review 

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -539,22 +539,6 @@ const DebugPage: React.FunctionComponent<Props> = ({
     transport,
   ]);
 
-  useEffect(() => {
-    const newApiId = method.id || method.name;
-    if (newApiId !== currentApiId) {
-      setCurrentApiId(newApiId);
-      if (responseCache[newApiId]) {
-        setDebugResponse(responseCache[newApiId].body);
-        setDebugResponseHeaders(
-          Array.from(responseCache[newApiId].headers.entries()),
-        );
-      } else {
-        setDebugResponse('');
-        setDebugResponseHeaders([]);
-      }
-    }
-  }, [method, currentApiId, responseCache]);
-
   const supportedExamplePaths = useMemo(() => {
     if (
       serviceType === ServiceType.HTTP ||

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -59,6 +59,12 @@ import { TRANSPORTS } from '../../lib/transports';
 import { SelectOption } from '../../lib/types';
 import DebugInputs from './DebugInputs';
 
+const stringifyHeaders = (headers: [string, string[]][]): string =>
+  JSON.stringify(
+    Object.fromEntries(headers.map(([key, value]) => [key, value.join(', ')])),
+    null,
+    2,
+  );
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     actionDialog: {
@@ -645,15 +651,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
                         style={githubGist}
                         wrapLines={false}
                       >
-                        {JSON.stringify(
-                          Object.fromEntries(
-                            Array.from(debugResponseHeaders).map(
-                              ([key, values]) => [key, values.join(', ')],
-                            ),
-                          ),
-                          null,
-                          2,
-                        )}
+                        {stringifyHeaders(debugResponseHeaders)}
                       </SyntaxHighlighter>
                     </>
                   )}
@@ -763,15 +761,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       style={githubGist}
                       wrapLines={false}
                     >
-                      {JSON.stringify(
-                        Object.fromEntries(
-                          Array.from(debugResponseHeaders).map(
-                            ([key, values]) => [key, values.join(', ')],
-                          ),
-                        ),
-                        null,
-                        2,
-                      )}
+                      {stringifyHeaders(debugResponseHeaders)}
                     </SyntaxHighlighter>
                   </>
                 )}

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -130,9 +130,11 @@ const toggle = (prev: boolean, override: unknown) => {
 
 const escapeSingleQuote = (text: string) => text.replace(/'/g, "'\\''");
 
+type Header = [name: string, value: string];
+
 interface ResponseData {
+  headers: Header[];
   body: string;
-  headers: Record<string, string>;
 }
 
 const DebugPage: React.FunctionComponent<Props> = ({
@@ -154,9 +156,9 @@ const DebugPage: React.FunctionComponent<Props> = ({
   const [requestBody, setRequestBody] = useState('');
   const [debugResponse, setDebugResponse] = useState('');
   const [additionalQueries, setAdditionalQueries] = useState('');
-  const [debugResponseHeaders, setDebugResponseHeaders] = useState<
-    Record<string, string>
-  >({});
+  const [debugResponseHeaders, setDebugResponseHeaders] = useState<Header[]>(
+    [],
+  );
   const [additionalPath, setAdditionalPath] = useState('');
   const [additionalHeaders, setAdditionalHeaders] = useState('');
   const [stickyHeaders, toggleStickyHeaders] = useReducer(toggle, false);
@@ -190,7 +192,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
         setDebugResponseHeaders(responseCache[apiId].headers);
       } else {
         setDebugResponse('');
-        setDebugResponseHeaders({});
+        setDebugResponseHeaders([]);
       }
     }
   }, [method, currentApiId, responseCache]);
@@ -231,7 +233,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
     if (!keepDebugResponse) {
       setDebugResponse('');
-      setDebugResponseHeaders({});
+      setDebugResponseHeaders([]);
       toggleKeepDebugResponse(false);
     }
     setSnackbarOpen(false);
@@ -394,7 +396,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
   const onClear = useCallback(() => {
     setDebugResponse('');
-    setDebugResponseHeaders({});
+    setDebugResponseHeaders([]);
   }, []);
 
   const executeRequest = useCallback(
@@ -431,15 +433,15 @@ const DebugPage: React.FunctionComponent<Props> = ({
           queries,
         );
         setDebugResponse(body);
-        setDebugResponseHeaders(responseHeaders);
+        setDebugResponseHeaders(Object.entries(responseHeaders));
         setResponseCache((prev) => ({
           ...prev,
-          [currentApiId]: { body, headers: responseHeaders },
+          [currentApiId]: { body, headers: Object.entries(responseHeaders) },
         }));
       } catch (e) {
         const message = e instanceof Object ? e.toString() : '<unknown>';
         setDebugResponse(message);
-        setDebugResponseHeaders({});
+        setDebugResponseHeaders([]);
       }
     },
     [
@@ -548,7 +550,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
         setDebugResponseHeaders(responseCache[newApiId].headers);
       } else {
         setDebugResponse('');
-        setDebugResponseHeaders({});
+        setDebugResponseHeaders([]);
       }
     }
   }, [method, currentApiId, responseCache]);
@@ -659,7 +661,11 @@ const DebugPage: React.FunctionComponent<Props> = ({
                         style={githubGist}
                         wrapLines={false}
                       >
-                        {JSON.stringify(debugResponseHeaders, null, 2)}
+                        {JSON.stringify(
+                          Object.fromEntries(debugResponseHeaders),
+                          null,
+                          2,
+                        )}
                       </SyntaxHighlighter>
                     </>
                   )}
@@ -769,7 +775,11 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       style={githubGist}
                       wrapLines={false}
                     >
-                      {JSON.stringify(debugResponseHeaders, null, 2)}
+                      {JSON.stringify(
+                        Object.fromEntries(debugResponseHeaders),
+                        null,
+                        2,
+                      )}
                     </SyntaxHighlighter>
                   </>
                 )}

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -168,9 +168,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
     false,
   );
 
-  const [currentApiId, setCurrentApiId] = useState<string>(
-    method.id || method.name,
-  );
+  const [currentApiId, setCurrentApiId] = useState<string>(method.id);
   const [responseCache, setResponseCache] = useState<
     Record<string, { body: string; headers: Map<string, string[]> }>
   >({});
@@ -183,7 +181,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
   }
 
   useEffect(() => {
-    const apiId = method.id || method.name;
+    const apiId = method.id;
     if (apiId !== currentApiId) {
       setCurrentApiId(apiId);
       if (responseCache[apiId]) {

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -340,23 +340,23 @@ const DebugPage: React.FunctionComponent<Props> = ({
         escapeSingleQuote(requestBody),
       );
 
-      const headersObj = new Headers();
-      headersObj.set('content-type', transport.getDebugMimeType());
+      const headers = new Headers();
+      headers.set('content-type', transport.getDebugMimeType());
       if (process.env.WEBPACK_DEV === 'true') {
-        headersObj.set(docServiceDebug, 'true');
+        headers.set(docServiceDebug, 'true');
       }
       if (serviceType === ServiceType.GRAPHQL) {
-        headersObj.set('accept', 'application/json');
+        headers.set('accept', 'application/json');
       }
       if (additionalHeaders) {
         const entries = Object.entries(JSON.parse(additionalHeaders));
         entries.forEach(([key, value]) => {
-          headersObj.set(key, String(value));
+          headers.set(key, String(value));
         });
       }
 
       const headerOptions: string[] = [];
-      headersObj.forEach((value, key) => {
+      headers.forEach((value, key) => {
         headerOptions.push(`-H '${key}: ${value}'`);
       });
 

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -295,6 +295,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
       }
 
       // window.location.origin may have compatibility issue
+      // https://developer.mozilla.org/en-US/docs/Web/API/Window/location#Browser_compatibility
       const host =
         `${window.location.protocol}//${window.location.hostname}` +
         `${window.location.port ? `:${window.location.port}` : ''}`;
@@ -461,6 +462,10 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
     try {
       if (useRequestBody) {
+        // Do not round-trip through JSON.parse to minify the text so as to not lose numeric precision.
+        // See: https://github.com/line/armeria/issues/273
+
+        // For some reason jsonMinify minifies {} as empty string, so work around it.
         params.set('request_body', jsonMinify(requestBody) || '{}');
       }
 
@@ -477,6 +482,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
       } else if (additionalPath.length > 0) {
         params.set('endpoint_path', additionalPath);
       } else {
+        // Fall back to default endpoint.
         params.delete('endpoint_path');
       }
 
@@ -511,6 +517,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
     const serializedParams = `?${params.toString()}`;
     if (serializedParams !== location.search) {
+      // executeRequest may throw error before useEffect, we need to avoid useEffect cleanup the debug response.
       toggleKeepDebugResponse(true);
       history.push(`${location.pathname}${serializedParams}`);
     }

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -663,11 +663,9 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       >
                         {JSON.stringify(
                           Object.fromEntries(
-                            debugResponseHeaders
-                              .entries()
-                              .flatMap(([key, values]) =>
-                                values.map((value) => [key, value]),
-                              ),
+                            Array.from(debugResponseHeaders).map(
+                              ([key, values]) => [key, values.join(', ')],
+                            ),
                           ),
                           null,
                           2,
@@ -783,9 +781,8 @@ const DebugPage: React.FunctionComponent<Props> = ({
                     >
                       {JSON.stringify(
                         Object.fromEntries(
-                          Array.from(debugResponseHeaders.entries()).flatMap(
-                            ([key, values]) =>
-                              values.map((value) => [key, value]),
+                          Array.from(debugResponseHeaders).map(
+                            ([key, values]) => [key, values.join(', ')],
                           ),
                         ),
                         null,

--- a/docs-client/src/lib/json-util.ts
+++ b/docs-client/src/lib/json-util.ts
@@ -134,3 +134,17 @@ export function isValidJsonMimeType(applicationType: string | null) {
   }
   return applicationType.indexOf('json') >= 0;
 }
+
+export function extractResponseHeaders(
+  headers: Headers,
+): Map<string, string[]> {
+  const responseHeaders = new Map<string, string[]>();
+  headers.forEach((value, key) => {
+    const lowerKey = key.toLowerCase();
+    if (!responseHeaders.has(lowerKey)) {
+      responseHeaders.set(lowerKey, []);
+    }
+    responseHeaders.get(lowerKey)!.push(value);
+  });
+  return responseHeaders;
+}

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -16,7 +16,11 @@
 import { Endpoint, Method } from '../specification';
 
 import Transport from './transport';
-import { isValidJsonMimeType, validateJsonObject } from '../json-util';
+import {
+  extractResponseHeaders,
+  isValidJsonMimeType,
+  validateJsonObject,
+} from '../json-util';
 import { ResponseData } from '../types';
 
 export const ANNOTATED_HTTP_MIME_TYPE = 'application/json; charset=utf-8';
@@ -123,15 +127,7 @@ export default class AnnotatedHttpTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/grahpql-http.ts
+++ b/docs-client/src/lib/transports/grahpql-http.ts
@@ -16,7 +16,7 @@
 
 import Transport from './transport';
 import { Method } from '../specification';
-import { validateJsonObject } from '../json-util';
+import { extractResponseHeaders, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const GRAPHQL_HTTP_MIME_TYPE = 'application/graphql+json';
@@ -66,15 +66,7 @@ export default class GraphqlHttpTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/grpc-unframed.ts
+++ b/docs-client/src/lib/transports/grpc-unframed.ts
@@ -16,7 +16,7 @@
 import { Method } from '../specification';
 
 import Transport from './transport';
-import { validateJsonObject } from '../json-util';
+import { extractResponseHeaders, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const GRPC_UNFRAMED_MIME_TYPE =
@@ -63,15 +63,7 @@ export default class GrpcUnframedTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/thrift.ts
+++ b/docs-client/src/lib/transports/thrift.ts
@@ -17,7 +17,7 @@
 import { Endpoint, Method } from '../specification';
 
 import Transport from './transport';
-import { validateJsonObject } from '../json-util';
+import { extractResponseHeaders, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const TTEXT_MIME_TYPE = 'application/x-thrift; protocol=TTEXT';
@@ -73,15 +73,7 @@ export default class ThriftTransport extends Transport {
       body: `{"method": "${thriftMethod}", "type": "CALL", "args": ${bodyJson}}`,
     });
 
-    const responseHeaders = new Map<string, string[]>();
-    response.headers.forEach((value, key) => {
-      const lowerKey = key.toLowerCase();
-      if (!responseHeaders.has(lowerKey)) {
-        responseHeaders.set(lowerKey, []);
-      }
-      responseHeaders.get(lowerKey)!.push(value);
-    });
-
+    const responseHeaders = extractResponseHeaders(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -16,8 +16,8 @@
 import JSONbig from 'json-bigint';
 import { jsonPrettify } from '../json-util';
 import { docServiceDebug, providers } from '../header-provider';
-
 import { Endpoint, Method } from '../specification';
+import { ResponseData } from '../types';
 
 export default abstract class Transport {
   public abstract supportsMimeType(mimeType: string): boolean;
@@ -31,7 +31,7 @@ export default abstract class Transport {
     bodyJson?: string,
     endpointPath?: string,
     queries?: string,
-  ): Promise<{ body: string; headers: Record<string, string> }> {
+  ): Promise<ResponseData> {
     const providedHeaders = await Promise.all(
       providers.map((provider) => provider()),
     );
@@ -59,9 +59,9 @@ export default abstract class Transport {
       endpointPath,
       queries,
     );
-    const responseHeaders = this.extractHeaders(httpResponse.headers);
-    const responseText = await httpResponse.text();
-    const applicationType = httpResponse.headers.get('content-type') || '';
+    const responseHeaders = httpResponse.headers;
+    const responseText = httpResponse.body;
+    const applicationType = responseHeaders.get('content-type') || '';
     if (applicationType.indexOf('json') >= 0) {
       try {
         const json = JSONbig.parse(responseText);
@@ -181,5 +181,5 @@ export default abstract class Transport {
     bodyJson?: string,
     endpointPath?: string,
     queries?: string,
-  ): Promise<Response>;
+  ): Promise<ResponseData>;
 }

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -92,14 +92,6 @@ export default abstract class Transport {
     };
   }
 
-  protected extractHeaders(headers: Headers): Record<string, string> {
-    const result: Record<string, string> = {};
-    headers.forEach((value, key) => {
-      result[key] = value;
-    });
-    return result;
-  }
-
   public findDebugMimeTypeEndpoint(
     method: Method,
     endpointPath?: string,

--- a/docs-client/src/lib/types.ts
+++ b/docs-client/src/lib/types.ts
@@ -24,3 +24,8 @@ export enum SpecLoadingStatus {
   FAILED,
   SUCCESS,
 }
+
+export interface ResponseData {
+  body: string;
+  headers: Map<string, string[]>;
+}


### PR DESCRIPTION
Motivation
Initially, all headers were split by commas without considering their semantics. However, RFC 9110 specifies that only headers defined with the #element syntax can be safely split or merged. Others, like Date or Set-Cookie, must be preserved as-is to avoid data loss.

Modification
Updated the logic to only split list-type headers (e.g., Accept, x-role) and preserve all others in their original form. Header values are now processed line-by-line based on whether they’re splittable per RFC 9110.

Result
Improved accuracy and readability of response headers. Headers with multiple values (e.g., x-role) are displayed on separate lines, while sensitive fields like Date and Set-Cookie are preserved correctly. Order and duplication are now reliably maintained.