### PR TITLE
Update review

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -149,9 +149,9 @@ const DebugPage: React.FunctionComponent<Props> = ({
   const [requestBody, setRequestBody] = useState('');
   const [debugResponse, setDebugResponse] = useState('');
   const [additionalQueries, setAdditionalQueries] = useState('');
-  const [debugResponseHeaders, setDebugResponseHeaders] = useState<
-    [string, string[]][]
-  >([]);
+  const [debugResponseHeaders, setDebugResponseHeaders] = useState<string[]>(
+    [],
+  );
   const [additionalPath, setAdditionalPath] = useState('');
   const [additionalHeaders, setAdditionalHeaders] = useState('');
   const [stickyHeaders, toggleStickyHeaders] = useReducer(toggle, false);
@@ -164,7 +164,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
   const [currentApiId, setCurrentApiId] = useState<string>(method.id);
   const [responseCache, setResponseCache] = useState<
-    Record<string, { body: string; headers: Map<string, string[]> }>
+    Record<string, { body: string; headers: string[] }>
   >({});
 
   const classes = useStyles();
@@ -180,9 +180,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
       setCurrentApiId(apiId);
       if (responseCache[apiId]) {
         setDebugResponse(responseCache[apiId].body);
-        setDebugResponseHeaders(
-          Array.from(responseCache[apiId].headers.entries()),
-        );
+        setDebugResponseHeaders(responseCache[apiId].headers);
       } else {
         setDebugResponse('');
         setDebugResponseHeaders([]);
@@ -426,7 +424,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
           queries,
         );
         setDebugResponse(body);
-        setDebugResponseHeaders(Array.from(responseHeaders.entries()));
+        setDebugResponseHeaders(responseHeaders);
         setResponseCache((prev) => ({
           ...prev,
           [currentApiId]: {
@@ -639,11 +637,11 @@ const DebugPage: React.FunctionComponent<Props> = ({
                         Response Headers:
                       </Typography>
                       <SyntaxHighlighter
-                        language="json"
+                        language="text"
                         style={githubGist}
                         wrapLines={false}
                       >
-                        {stringifyHeaders(debugResponseHeaders)}
+                        {debugResponseHeaders.join('\n')}
                       </SyntaxHighlighter>
                     </>
                   )}
@@ -749,11 +747,11 @@ const DebugPage: React.FunctionComponent<Props> = ({
                       Response Headers:
                     </Typography>
                     <SyntaxHighlighter
-                      language="json"
+                      language="text"
                       style={githubGist}
                       wrapLines={false}
                     >
-                      {stringifyHeaders(debugResponseHeaders)}
+                      {debugResponseHeaders.join('\n')}
                     </SyntaxHighlighter>
                   </>
                 )}

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -59,12 +59,6 @@ import { TRANSPORTS } from '../../lib/transports';
 import { SelectOption } from '../../lib/types';
 import DebugInputs from './DebugInputs';
 
-const stringifyHeaders = (headers: [string, string[]][]): string =>
-  JSON.stringify(
-    Object.fromEntries(headers.map(([key, value]) => [key, value.join(', ')])),
-    null,
-    2,
-  );
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     actionDialog: {

--- a/docs-client/src/lib/json-util.ts
+++ b/docs-client/src/lib/json-util.ts
@@ -14,6 +14,8 @@
  * under the License.
  */
 
+import { listHeaders } from './types';
+
 function doPrettify(ch: string, indentation: number): [string, number] {
   let prettified;
   let newIndentation = indentation;
@@ -135,16 +137,16 @@ export function isValidJsonMimeType(applicationType: string | null) {
   return applicationType.indexOf('json') >= 0;
 }
 
-export function extractResponseHeaders(
-  headers: Headers,
-): Map<string, string[]> {
-  const responseHeaders = new Map<string, string[]>();
-  headers.forEach((value, key) => {
-    const lowerKey = key.toLowerCase();
-    if (!responseHeaders.has(lowerKey)) {
-      responseHeaders.set(lowerKey, []);
+export function extractHeaderLines(headers: Headers): string[] {
+  const headerLines: string[] = [];
+  headers.forEach((value, name) => {
+    if (listHeaders.has(name.toLowerCase())) {
+      value.split(',').forEach((v) => {
+        headerLines.push(`${name}: ${v.trim()}`);
+      });
+    } else {
+      headerLines.push(`${name}: ${value}`);
     }
-    responseHeaders.get(lowerKey)!.push(value);
   });
-  return responseHeaders;
+  return headerLines;
 }

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -17,7 +17,7 @@ import { Endpoint, Method } from '../specification';
 
 import Transport from './transport';
 import {
-  extractResponseHeaders,
+  extractHeaderLines,
   isValidJsonMimeType,
   validateJsonObject,
 } from '../json-util';
@@ -127,7 +127,7 @@ export default class AnnotatedHttpTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = extractResponseHeaders(response.headers);
+    const responseHeaders = extractHeaderLines(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/grahpql-http.ts
+++ b/docs-client/src/lib/transports/grahpql-http.ts
@@ -16,7 +16,7 @@
 
 import Transport from './transport';
 import { Method } from '../specification';
-import { extractResponseHeaders, validateJsonObject } from '../json-util';
+import { extractHeaderLines, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const GRAPHQL_HTTP_MIME_TYPE = 'application/graphql+json';
@@ -66,7 +66,7 @@ export default class GraphqlHttpTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = extractResponseHeaders(response.headers);
+    const responseHeaders = extractHeaderLines(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/grpc-unframed.ts
+++ b/docs-client/src/lib/transports/grpc-unframed.ts
@@ -16,7 +16,7 @@
 import { Method } from '../specification';
 
 import Transport from './transport';
-import { extractResponseHeaders, validateJsonObject } from '../json-util';
+import { extractHeaderLines, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const GRPC_UNFRAMED_MIME_TYPE =
@@ -63,7 +63,7 @@ export default class GrpcUnframedTransport extends Transport {
       body: bodyJson,
     });
 
-    const responseHeaders = extractResponseHeaders(response.headers);
+    const responseHeaders = extractHeaderLines(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/thrift.ts
+++ b/docs-client/src/lib/transports/thrift.ts
@@ -17,7 +17,7 @@
 import { Endpoint, Method } from '../specification';
 
 import Transport from './transport';
-import { extractResponseHeaders, validateJsonObject } from '../json-util';
+import { extractHeaderLines, validateJsonObject } from '../json-util';
 import { ResponseData } from '../types';
 
 export const TTEXT_MIME_TYPE = 'application/x-thrift; protocol=TTEXT';
@@ -73,7 +73,7 @@ export default class ThriftTransport extends Transport {
       body: `{"method": "${thriftMethod}", "type": "CALL", "args": ${bodyJson}}`,
     });
 
-    const responseHeaders = extractResponseHeaders(response.headers);
+    const responseHeaders = extractHeaderLines(response.headers);
     const responseText = await response.text();
 
     return {

--- a/docs-client/src/lib/transports/transport.ts
+++ b/docs-client/src/lib/transports/transport.ts
@@ -13,8 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import JSONbig from 'json-bigint';
-import { jsonPrettify } from '../json-util';
 import { docServiceDebug, providers } from '../header-provider';
 import { Endpoint, Method } from '../specification';
 import { ResponseData } from '../types';
@@ -61,24 +59,6 @@ export default abstract class Transport {
     );
     const responseHeaders = httpResponse.headers;
     const responseText = httpResponse.body;
-    const applicationType = responseHeaders.get('content-type') || '';
-    if (applicationType.indexOf('json') >= 0) {
-      try {
-        const json = JSONbig.parse(responseText);
-        const prettified = jsonPrettify(JSONbig.stringify(json));
-        if (prettified.length > 0) {
-          return {
-            body: prettified,
-            headers: responseHeaders,
-          };
-        }
-      } catch (e) {
-        return {
-          body: responseText,
-          headers: responseHeaders,
-        };
-      }
-    }
 
     if (responseText.length > 0) {
       return {

--- a/docs-client/src/lib/types.ts
+++ b/docs-client/src/lib/types.ts
@@ -52,5 +52,5 @@ export const listHeaders = new Set([
 
 export interface ResponseData {
   body: string;
-  headers: Map<string, string[]>;
+  headers: string[];
 }

--- a/docs-client/src/lib/types.ts
+++ b/docs-client/src/lib/types.ts
@@ -25,6 +25,31 @@ export enum SpecLoadingStatus {
   SUCCESS,
 }
 
+export const listHeaders = new Set([
+  'accept',
+  'accept-charset',
+  'accept-encoding',
+  'accept-language',
+  'allow',
+  'cache-control',
+  'connection',
+  'content-encoding',
+  'content-language',
+  'expect',
+  'if-match',
+  'if-none-match',
+  'pragma',
+  'proxy-authenticate',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'vary',
+  'via',
+  'warning',
+  'www-authenticate',
+]);
+
 export interface ResponseData {
   body: string;
   headers: Map<string, string[]>;


### PR DESCRIPTION
Motivation
Initially, all headers were split by commas without considering their semantics. However, RFC 9110 specifies that only headers defined with the #element syntax can be safely split or merged. Others, like Date or Set-Cookie, must be preserved as-is to avoid data loss.

Modification
Updated the logic to only split list-type headers (e.g., Accept, x-role) and preserve all others in their original form. Header values are now processed line-by-line based on whether they’re splittable per RFC 9110.

Result
Improved accuracy and readability of response headers. Headers with multiple values (e.g., x-role) are displayed on separate lines, while sensitive fields like Date and Set-Cookie are preserved correctly. Order and duplication are now reliably maintained.